### PR TITLE
feat(agent-manage): add copy/paste pane content to clipboard

### DIFF
--- a/bin/agent-manage
+++ b/bin/agent-manage
@@ -13,6 +13,46 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+# Cross-platform clipboard copy
+copy_to_clipboard() {
+    local content="$1"
+
+    if command -v pbcopy &>/dev/null; then
+        echo -n "$content" | pbcopy
+    elif command -v xclip &>/dev/null; then
+        echo -n "$content" | xclip -selection clipboard
+    elif command -v xsel &>/dev/null; then
+        echo -n "$content" | xsel --clipboard --input
+    elif command -v wl-copy &>/dev/null; then
+        echo -n "$content" | wl-copy
+    elif command -v clip.exe &>/dev/null; then
+        echo -n "$content" | clip.exe
+    else
+        echo -e "${RED}No clipboard tool found${NC}"
+        echo "Install one of: pbcopy (macOS), xclip, xsel (Linux), wl-copy (Wayland)"
+        return 1
+    fi
+}
+
+# Cross-platform clipboard paste
+paste_from_clipboard() {
+    if command -v pbpaste &>/dev/null; then
+        pbpaste
+    elif command -v xclip &>/dev/null; then
+        xclip -selection clipboard -o
+    elif command -v xsel &>/dev/null; then
+        xsel --clipboard --output
+    elif command -v wl-paste &>/dev/null; then
+        wl-paste
+    elif command -v powershell.exe &>/dev/null; then
+        powershell.exe -command "Get-Clipboard" | tr -d '\r'
+    else
+        echo -e "${RED}No clipboard tool found${NC}" >&2
+        echo "Install one of: pbpaste (macOS), xclip, xsel (Linux), wl-paste (Wayland)" >&2
+        return 1
+    fi
+}
+
 show_help() {
     cat << 'EOF'
 agent-manage - Manage tmux agent panes and sessions
@@ -29,6 +69,9 @@ COMMANDS:
     kill, k <target>    Kill session(s): 'all', session name, or pane index
     rename, r <n> <name> Rename pane by index
     focus, f <n|name>   Focus on pane by index or name
+    copy, cp [n|name]   Copy pane content to clipboard (interactive if no target)
+    copy-full, cpf [n|name] Copy full scrollback history to clipboard
+    paste, p [n|name]   Paste clipboard content to pane (interactive if no target)
     layout, l           Rebalance pane layout (even-horizontal)
     list, ls            List all tmux sessions
 
@@ -40,6 +83,9 @@ EXAMPLES:
     agent-manage add 2               # Add 2 new panes
     agent-manage add 2 DEBUG TEST    # Add 2 panes named DEBUG and TEST
     agent-manage close 3             # Close pane 3
+    agent-manage copy 0              # Copy pane 0 content to clipboard
+    agent-manage copy-full WORK      # Copy full history of WORK pane
+    agent-manage paste 1             # Paste clipboard to pane 1
     agent-manage kill agents         # Kill 'agents' session
     agent-manage kill all            # Kill ALL tmux sessions
 
@@ -244,6 +290,244 @@ cmd_list() {
     tmux list-sessions 2>/dev/null || echo -e "${YELLOW}No tmux sessions running.${NC}"
 }
 
+# Copy pane content to clipboard (visible content only)
+cmd_copy() {
+    check_session
+
+    local target="$1"
+    local pane_idx
+
+    # If target provided, use it directly
+    if [[ -n "$target" ]]; then
+        if [[ "$target" =~ ^[0-9]+$ ]]; then
+            pane_idx="$target"
+        else
+            # Find pane by name
+            pane_idx=$(tmux list-panes -t "$SESSION_NAME" -F "#{pane_index}:#{pane_title}" | grep ":$target" | cut -d: -f1 | head -1)
+            if [[ -z "$pane_idx" ]]; then
+                echo -e "${RED}Pane '$target' not found${NC}"
+                return 1
+            fi
+        fi
+    else
+        # Interactive selection with fzf
+        if ! command -v fzf &>/dev/null; then
+            echo -e "${RED}fzf required for interactive selection${NC}"
+            return 1
+        fi
+
+        local panes
+        panes=$(tmux list-panes -t "$SESSION_NAME" \
+            -F "#{pane_index}|#{pane_title}|#{pane_current_command}" 2>/dev/null)
+
+        if [ -z "$panes" ]; then
+            echo -e "${RED}No panes found in session${NC}"
+            return 1
+        fi
+
+        # Format for display
+        local display=""
+        while IFS='|' read -r idx title cmd; do
+            display+="$idx: $title ($cmd)"$'\n'
+        done <<< "$panes"
+
+        local selected
+        selected=$(echo -e "$display" | sed '/^$/d' | fzf \
+            --height=50% \
+            --layout=reverse \
+            --border=rounded \
+            --prompt="Select pane to copy › " \
+            --header="Copy pane content to clipboard" \
+            --preview="tmux capture-pane -p -S -20 -t '$SESSION_NAME.{1}' 2>/dev/null | head -20" \
+            --preview-window=right:50%:wrap)
+
+        [ -z "$selected" ] && return 0
+
+        pane_idx=$(echo "$selected" | cut -d: -f1 | tr -d ' ')
+    fi
+
+    # Capture pane content (visible only, strip ANSI codes)
+    local content
+    content=$(tmux capture-pane -p -t "$SESSION_NAME.$pane_idx" 2>/dev/null | \
+        sed 's/\x1b\[[0-9;]*m//g')
+
+    if [ -z "$content" ] || [ "$(echo "$content" | tr -d '[:space:]')" = "" ]; then
+        echo -e "${YELLOW}Pane is empty (nothing to copy)${NC}"
+        return 0
+    fi
+
+    if ! copy_to_clipboard "$content"; then
+        return 1
+    fi
+
+    local line_count
+    line_count=$(echo "$content" | wc -l | tr -d ' ')
+
+    echo -e "${GREEN}Copied $line_count lines to clipboard${NC}"
+}
+
+# Copy pane content to clipboard (full scrollback history)
+cmd_copy_full() {
+    check_session
+
+    local target="$1"
+    local pane_idx
+
+    # If target provided, use it directly
+    if [[ -n "$target" ]]; then
+        if [[ "$target" =~ ^[0-9]+$ ]]; then
+            pane_idx="$target"
+        else
+            pane_idx=$(tmux list-panes -t "$SESSION_NAME" -F "#{pane_index}:#{pane_title}" | grep ":$target" | cut -d: -f1 | head -1)
+            if [[ -z "$pane_idx" ]]; then
+                echo -e "${RED}Pane '$target' not found${NC}"
+                return 1
+            fi
+        fi
+    else
+        # Interactive selection with fzf
+        if ! command -v fzf &>/dev/null; then
+            echo -e "${RED}fzf required for interactive selection${NC}"
+            return 1
+        fi
+
+        local panes
+        panes=$(tmux list-panes -t "$SESSION_NAME" \
+            -F "#{pane_index}|#{pane_title}|#{pane_current_command}" 2>/dev/null)
+
+        if [ -z "$panes" ]; then
+            echo -e "${RED}No panes found in session${NC}"
+            return 1
+        fi
+
+        local display=""
+        while IFS='|' read -r idx title cmd; do
+            display+="$idx: $title ($cmd)"$'\n'
+        done <<< "$panes"
+
+        local selected
+        selected=$(echo -e "$display" | sed '/^$/d' | fzf \
+            --height=50% \
+            --layout=reverse \
+            --border=rounded \
+            --prompt="Select pane to copy (full history) › " \
+            --header="Copy FULL scrollback to clipboard" \
+            --preview="tmux capture-pane -p -S - -t '$SESSION_NAME.{1}' 2>/dev/null | tail -30" \
+            --preview-window=right:50%:wrap)
+
+        [ -z "$selected" ] && return 0
+
+        pane_idx=$(echo "$selected" | cut -d: -f1 | tr -d ' ')
+    fi
+
+    # Capture full scrollback (-S - means from start of history)
+    local content
+    content=$(tmux capture-pane -p -S - -t "$SESSION_NAME.$pane_idx" 2>/dev/null | \
+        sed 's/\x1b\[[0-9;]*m//g')
+
+    if [ -z "$content" ] || [ "$(echo "$content" | tr -d '[:space:]')" = "" ]; then
+        echo -e "${YELLOW}Pane is empty (nothing to copy)${NC}"
+        return 0
+    fi
+
+    if ! copy_to_clipboard "$content"; then
+        return 1
+    fi
+
+    local line_count
+    line_count=$(echo "$content" | wc -l | tr -d ' ')
+
+    echo -e "${GREEN}Copied $line_count lines (full history) to clipboard${NC}"
+}
+
+# Paste clipboard content to pane
+cmd_paste() {
+    check_session
+
+    local target="$1"
+    local pane_idx
+
+    # Get clipboard content first
+    local content
+    content=$(paste_from_clipboard 2>/dev/null)
+
+    if [ -z "$content" ]; then
+        echo -e "${YELLOW}Clipboard is empty (nothing to paste)${NC}"
+        return 0
+    fi
+
+    # If target provided, use it directly
+    if [[ -n "$target" ]]; then
+        if [[ "$target" =~ ^[0-9]+$ ]]; then
+            pane_idx="$target"
+        else
+            pane_idx=$(tmux list-panes -t "$SESSION_NAME" -F "#{pane_index}:#{pane_title}" | grep ":$target" | cut -d: -f1 | head -1)
+            if [[ -z "$pane_idx" ]]; then
+                echo -e "${RED}Pane '$target' not found${NC}"
+                return 1
+            fi
+        fi
+    else
+        # Interactive selection with fzf
+        if ! command -v fzf &>/dev/null; then
+            echo -e "${RED}fzf required for interactive selection${NC}"
+            return 1
+        fi
+
+        local panes
+        panes=$(tmux list-panes -t "$SESSION_NAME" \
+            -F "#{pane_index}|#{pane_title}|#{pane_current_command}" 2>/dev/null)
+
+        if [ -z "$panes" ]; then
+            echo -e "${RED}No panes found in session${NC}"
+            return 1
+        fi
+
+        local display=""
+        while IFS='|' read -r idx title cmd; do
+            display+="$idx: $title ($cmd)"$'\n'
+        done <<< "$panes"
+
+        # Show preview of clipboard content
+        local preview_content
+        preview_content=$(echo "$content" | head -20)
+
+        local selected
+        selected=$(echo -e "$display" | sed '/^$/d' | fzf \
+            --height=50% \
+            --layout=reverse \
+            --border=rounded \
+            --prompt="Select pane to paste into › " \
+            --header="Paste clipboard to pane" \
+            --preview="echo 'Clipboard content:'; echo '─────────────────'; echo '$preview_content'" \
+            --preview-window=right:50%:wrap)
+
+        [ -z "$selected" ] && return 0
+
+        pane_idx=$(echo "$selected" | cut -d: -f1 | tr -d ' ')
+    fi
+
+    local line_count
+    line_count=$(echo "$content" | wc -l | tr -d ' ')
+
+    # Confirm before pasting multi-line content
+    if [ "$line_count" -gt 1 ]; then
+        echo -e "${YELLOW}About to paste $line_count lines to pane $pane_idx${NC}"
+        echo -e "${YELLOW}First line: $(echo "$content" | head -1 | cut -c1-60)...${NC}"
+        read -p "Continue? [y/N]: " confirm
+        if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+            echo -e "${YELLOW}Cancelled${NC}"
+            return 0
+        fi
+    fi
+
+    # Send content to pane using tmux send-keys
+    # Use -l to send literal string (doesn't interpret special keys)
+    tmux send-keys -t "$SESSION_NAME.$pane_idx" -l "$content"
+
+    echo -e "${GREEN}Pasted $line_count lines to pane $pane_idx${NC}"
+}
+
 # Interactive main menu
 cmd_menu() {
     if ! command -v fzf &> /dev/null; then
@@ -277,6 +561,9 @@ cmd_menu() {
         menu+="📐 Layout - rebalance panes"$'\n'
         menu+="🏷️  Rename pane"$'\n'
         menu+="🎯 Focus pane"$'\n'
+        menu+="📋 Copy pane"$'\n'
+        menu+="📜 Copy pane (full history)"$'\n'
+        menu+="📥 Paste to pane"$'\n'
         menu+="❌ Close pane"$'\n'
         menu+="💀 Kill session"$'\n'
 
@@ -341,6 +628,21 @@ cmd_menu() {
                 if [[ -n "$target" ]]; then
                     cmd_focus "$target"
                 fi
+                echo ""
+                read -p "Press Enter to continue..."
+                ;;
+            "📋 Copy pane")
+                cmd_copy
+                echo ""
+                read -p "Press Enter to continue..."
+                ;;
+            "📜 Copy pane (full history)")
+                cmd_copy_full
+                echo ""
+                read -p "Press Enter to continue..."
+                ;;
+            "📥 Paste to pane")
+                cmd_paste
                 echo ""
                 read -p "Press Enter to continue..."
                 ;;
@@ -455,6 +757,18 @@ case "${1:-}" in
     focus|f)
         shift
         cmd_focus "$@"
+        ;;
+    copy|cp)
+        shift
+        cmd_copy "$@"
+        ;;
+    copy-full|cpf)
+        shift
+        cmd_copy_full "$@"
+        ;;
+    paste|p)
+        shift
+        cmd_paste "$@"
         ;;
     layout|l)
         cmd_layout


### PR DESCRIPTION
## Summary

Add ability to copy pane content to system clipboard and paste clipboard content to panes. This enables quick extraction of agent output, logs, or terminal history without manual selection, and allows sending clipboard content directly to panes.

**New CLI commands:**
- `copy, cp [n|name]` - Copy visible pane content to clipboard
- `copy-full, cpf [n|name]` - Copy full scrollback history to clipboard
- `paste, p [n|name]` - Paste clipboard content to pane

**New menu options:**
- Copy pane
- Copy pane (full history)
- Paste to pane

**Features:**
- Interactive fzf picker when no target specified
- Cross-platform clipboard support (macOS, Linux X11, Wayland, WSL)
- ANSI escape code stripping for clean output
- Multi-line paste confirmation for safety
- Pane selection by index or name
- Preview of pane content/clipboard in fzf picker

## Testing

Tested on macOS with:
- [x] Copy by pane index (`agent-manage copy 0`)
- [x] Copy by pane name (`agent-manage copy PLAN`)
- [x] Copy full scrollback (`agent-manage copy-full 1`)
- [x] Paste single line content
- [x] Empty clipboard handling
- [x] Missing session error handling
- [x] Help text updated
- [x] Syntax validation passed

## Platform Support

| Platform | Copy Tool | Paste Tool |
|----------|-----------|------------|
| macOS | pbcopy | pbpaste |
| Linux X11 | xclip | xclip |
| Linux X11 (alt) | xsel | xsel |
| Wayland | wl-copy | wl-paste |
| WSL | clip.exe | powershell.exe |