### PR TITLE
docs: add open source community documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: Bug Report
+description: Report something that isn't working
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug clearly
+      placeholder: When I run agent-session, I see...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+      description: What should have happened instead?
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Run `agent-session`
+        2. Press Option+S
+        3. See error
+  - type: input
+    id: tmux-version
+    attributes:
+      label: tmux version
+      description: Output of `tmux -V`
+      placeholder: "tmux 3.4"
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - macOS
+        - Linux
+        - WSL2
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or error messages
+      description: Paste any error output here
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/barnierg76/agent-tmux-toolkit/discussions
+    about: Ask questions and discuss ideas
+  - name: Security Vulnerabilities
+    url: https://github.com/barnierg76/agent-tmux-toolkit/security/advisories/new
+    about: Report security issues privately

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: Feature Request
+description: Suggest an improvement or new feature
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case or pain point
+      placeholder: I often find myself needing to...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work?
+      placeholder: It would be great if...
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any other approaches you've thought about?
+  - type: dropdown
+    id: area
+    attributes:
+      label: Feature area
+      options:
+        - Session management
+        - Snippets
+        - Workflow orchestration
+        - Keybindings
+        - Git/worktree integration
+        - Documentation
+        - Other

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## What does this PR do?
+
+<!-- Brief description of the change -->
+
+## Related Issue
+
+<!-- Link to issue: Closes #123 -->
+
+## How to Test
+
+<!-- Steps to verify the changes work -->
+
+1. Run `./install.sh`
+2. Start `agent-session`
+3. ...
+
+## Checklist
+
+- [ ] I've run `shellcheck` on modified scripts
+- [ ] I've tested manually with `agent-session`
+- [ ] I've updated README if needed
+- [ ] My commits follow the project conventions

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best for the overall community
+
+Examples of unacceptable behavior:
+
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without their explicit permission
+* Other conduct which could reasonably be considered inappropriate
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported to the project maintainers.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing to Agent Tmux Toolkit
+
+Thank you for your interest in contributing! We welcome contributions of all types.
+
+## Quick Start
+
+1. Fork the repository
+2. Clone your fork: `git clone https://github.com/YOUR_USERNAME/agent-tmux-toolkit.git`
+3. Run `./install.sh` to set up
+4. Make your changes
+5. Test manually with `agent-session`
+6. Submit a pull request
+
+## Development Requirements
+
+- macOS or Linux (WSL2 on Windows may work but is untested)
+- tmux 3.0+ (tested with 3.2+)
+- Bash 4.0+
+- fzf for interactive pickers
+- git for worktree features
+- iTerm2 recommended for Option key support on macOS
+
+## Ways to Contribute
+
+### Report Bugs
+
+Open an issue using the [bug report template](https://github.com/barnierg76/agent-tmux-toolkit/issues/new?template=bug_report.yml).
+
+### Suggest Features
+
+Open an issue using the [feature request template](https://github.com/barnierg76/agent-tmux-toolkit/issues/new?template=feature_request.yml).
+
+### Submit Code
+
+1. Check [existing issues](../../issues) for something to work on
+2. Look for issues labeled [`good first issue`](../../labels/good%20first%20issue) if you're new
+3. Comment "I'd like to work on this" to claim it
+4. Fork, branch, implement, test
+5. Submit PR with clear description
+
+### Improve Documentation
+
+- Fix typos, clarify explanations
+- Add examples or use cases
+- No issue needed - just submit a PR
+
+## Coding Conventions
+
+### Shell Scripts
+
+- Use `#!/usr/bin/env bash` shebang
+- Run `shellcheck` before submitting
+- Use meaningful variable names
+- Comment complex logic
+- Follow existing patterns in `bin/agent-common.sh`
+
+### Git Commits
+
+- Present tense: "Add feature" not "Added feature"
+- Reference issues: "Fix pane selection (#123)"
+- Keep commits focused and atomic
+
+## Testing
+
+There's no automated test suite yet (contributions welcome!). Please test manually:
+
+```bash
+# Test session creation
+agent-session test-session
+
+# Test snippet picker
+# Press Option+S in tmux
+
+# Test workflow orchestration
+# Press Option+F in tmux
+
+# Clean up
+tmux kill-session -t test-session
+```
+
+## Getting Help
+
+- Open a [GitHub Discussion](https://github.com/barnierg76/agent-tmux-toolkit/discussions) for questions
+- Check existing issues for similar problems
+- Read the README and LEARNINGS.md for context
+
+## Review Timeline
+
+This is a volunteer project. We aim to review PRs within 7 days, but it may take longer.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant](CODE_OF_CONDUCT.md). Please be respectful and constructive in all interactions.

--- a/README.md
+++ b/README.md
@@ -267,3 +267,20 @@ agent-worktree --remove auth-module
 ## License
 
 MIT
+
+## Contributing
+
+We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
+
+### Quick Ways to Help
+
+- **Found a bug?** [Open an issue](../../issues/new?template=bug_report.yml)
+- **Have an idea?** [Request a feature](../../issues/new?template=feature_request.yml)
+- **Want to code?** Check issues labeled [`good first issue`](../../labels/good%20first%20issue)
+
+### Priority Areas
+
+- Improving error handling and validation
+- Adding test coverage
+- Documentation and examples
+- Cross-platform compatibility (Linux/WSL2)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities via GitHub Security Advisories:
+https://github.com/barnierg76/agent-tmux-toolkit/security/advisories/new
+
+**Do not open public issues for security vulnerabilities.**
+
+## Response Timeline
+
+- Acknowledgment: Within 72 hours
+- Initial assessment: Within 7 days
+- Fix timeline: Depends on severity
+
+## Scope
+
+This policy covers:
+
+- The shell scripts in `bin/`
+- The tmux configuration in `config/`
+- The installation script
+
+## What to Report
+
+- Command injection vulnerabilities
+- Unvalidated input handling
+- Privilege escalation issues
+- Information disclosure
+
+## Out of Scope
+
+- Issues in tmux itself (report to tmux maintainers)
+- Issues in fzf (report to fzf maintainers)
+- Social engineering attacks
+- Physical access attacks


### PR DESCRIPTION
## Summary

Add community engagement documentation to make it easy for open source contributors to discover, understand, and contribute to the project.

### Files Added
- **CONTRIBUTING.md** - Setup instructions, coding conventions, PR guidelines
- **CODE_OF_CONDUCT.md** - Contributor Covenant v2.1
- **SECURITY.md** - Vulnerability reporting instructions
- **.github/ISSUE_TEMPLATE/bug_report.yml** - Structured bug report form
- **.github/ISSUE_TEMPLATE/feature_request.yml** - Feature request form
- **.github/ISSUE_TEMPLATE/config.yml** - Disable blank issues, add contact links
- **.github/PULL_REQUEST_TEMPLATE.md** - PR checklist template

### Files Modified
- **README.md** - Added Contributing section with quick links

## Why

The project had excellent technical documentation but zero community infrastructure - no templates, guidelines, or onboarding docs despite being MIT-licensed.

## Testing

- [x] All markdown files render correctly
- [x] YAML issue templates have valid syntax
- [x] Links in README use relative paths

## Follow-up Tasks

After merge, create these GitHub labels:
- `good first issue` (green)
- `help wanted` (yellow)
- `bug` (red)
- `enhancement` (blue)
- `documentation` (purple)
- `question` (cyan)

Good first issue candidates from existing todos: #011, #018, #024